### PR TITLE
Update HTTP parser link

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ formats such as JSON, nom can manage it, and provides you with useful tools:
 
 Example projects:
 
-- [HTTP proxy](https://github.com/sozu-proxy/sozu/blob/master/lib/src/protocol/http/parser.rs)
+- [HTTP proxy](https://github.com/sozu-proxy/sozu/tree/main/lib/src/protocol/http/parser)
 - [TOML parser](https://github.com/joelself/tomllib)
 
 ### Programming language parsers
@@ -148,7 +148,7 @@ It allows you to build powerful, deterministic state machines for your protocols
 
 Example projects:
 
-- [HTTP proxy](https://github.com/sozu-proxy/sozu/blob/master/lib/src/protocol/http/parser.rs)
+- [HTTP proxy](https://github.com/sozu-proxy/sozu/tree/main/lib/src/protocol/http/parser)
 - [Using nom with generators](https://github.com/Geal/generator_nom)
 
 ## Parser combinators


### PR DESCRIPTION
Looks like `sozu-proxy` did a small [reorganization](https://github.com/sozu-proxy/sozu/commit/400ecb172ec123957217cf393a0c19902a6cdbb6#diff-83c358ea7f35b7dafef3c635cbeac4518162ecfb4e30d2e9f1b741b92fe4a7b4) of their repository. This PR updates `nom`'s README.md with a new link to their HTTP parser.